### PR TITLE
use `os.tmpdir()` polyfill for more consistent behaviour

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 var fs = require('fs');
-var os = require('os');
 var ps = require('path');
 var cs = require('crypto');
 var rm = require('rimraf');
+var tmpdir = require('os-tmpdir');
 
 
 var IS_WINDOWS = process.platform === 'win32';
@@ -32,22 +32,6 @@ process.addListener('exit', function (exitcode) {
 process.addListener('uncaughtException', function (err) {
   clearSync();
 });
-
-/* History:
- * https://github.com/joyent/node/blob/a11bf99ce0dae4d8f4de8a9c0c32159c1a9ecfbf/lib/os.js#L42-L47
- * https://github.com/joyent/node/blob/120e5a24df76deb5019abec9744ace94f0f3746a/lib/os.js#L45-L56
- * https://github.com/iojs/io.js/blob/6c80e38b014b7be570ffafa91032a6d67d7dd4ae/lib/os.js#L25-L40
- */
-function tmpdir() {
-  var path;
-  if (IS_WINDOWS) {
-    path = process.env.TEMP || process.env.TMP ||
-           (process.env.SystemRoot || process.env.windir) + '\\temp';
-  } else {
-    path = process.env.TMPDIR || process.env.TMP || process.env.TEMP || '/tmp';
-  }
-  return ps.resolve(path);
-}
 
 function track(on) {
   tracking = (on == null ? true : Boolean(on));

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "node node_modules/mocha/bin/mocha --reporter spec --bail test/*.js"
   },
   "dependencies": {
+    "os-tmpdir": "~1.0.0",
     "rimraf": "~2.3.3"
   },
   "files": [


### PR DESCRIPTION
The `os.tmpdir()` method has changed a lot between Node versions and it would be nice for users if it were consistent between Node versions. This might even prevent hard to track down bugs.

Node 0.10.38: https://github.com/joyent/node/blob/0b5731a63cc40c4fe9275c79158fe0a5dd4d1609/lib/os.js#L44-L49

io.js 2.0.1: https://github.com/iojs/io.js/blob/6c80e38b014b7be570ffafa91032a6d67d7dd4ae/lib/os.js#L25-L40

From io.js changelog:

> os.tmpdir() is now cross-platform consistent and will no longer returns a path with a trailling slash on any platform

> Updated os.tmpdir on Windows to use the %SystemRoot% or %WINDIR% environment variables instead of the hard-coded value of c:\windows when determining the temporary directory location.

---

https://github.com/sindresorhus/os-tmpdir