### PR TITLE
Bundle TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015 MEDIA CHECK s.r.o.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+interface dir {
+  path: String;
+  recursive: Boolean;
+  unlink(callback?:(error:Error)=>any): any;
+}
+
+interface file {
+  path: String;
+  fd: Number;
+  unlink(callback?:(error:Error)=>any): any;
+}
+
+interface options {
+  dir?: String;
+  limit?: Number;
+  mode?: Number;
+  name?: String;
+  prefix?: String;
+  recursive?: Boolean;
+  suffix?: String;
+  template?: String;
+  track?: Boolean;
+}
+
+export declare function clear(callback?:()=>any):any;
+
+export declare function clearSync():any;
+
+export declare function dir():string;
+
+export declare function mkdir(options?:options, callback?:(err:any, dir:dir)=>any):any;
+
+export declare function mkdirSync(options?:options):dir;
+
+export declare function name(options?:options):string;
+
+export declare function open(options?:options, callback?:(err:any, file:file)=>any):any;
+
+export declare function openSync(options?:options):file;
+
+export declare function track(on?:Boolean):void;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "files": [
     "LICENSE",
     "README.md",
+    "index.d.ts",
     "index.js"
   ],
   "keywords": [


### PR DESCRIPTION
Hi,

I'm using your library from my TypeScript code. In order to use a JavaScript code from a TypeScript code, it's necessary to provide a ".d.ts" file that provides declarations. I can bundle this file with my code but I think that it would be nice if it would be available to others as well.

OTOH, I would understand if you would not like the idea of distributing this file with your code. In that case, I would attempt to upload it to http://definitelytyped.org/, a repository of type declarations. The benefit of distributing it with the library is that its authors may try to keep it up-to-date [1]. I can maintain it here for you if you want.

Please let me know if there is any problem/ugliness. I will be happy to make the contribution as perfect as possible. E.g. would you like me to add a test? I think it would follow [2] in that case.

Please note that according to our laws, the contribution copyright belongs to MEDIA CHECK s.r.o. (my employer).

[1] http://blog.johnnyreilly.com/2015/09/authoring-npm-modules-with-typescript.html
[2] http://definitelytyped.org/guides/contributing.html#tests